### PR TITLE
Add, uh, checkout method. Yeah.

### DIFF
--- a/checkThisOut.js
+++ b/checkThisOut.js
@@ -1,0 +1,10 @@
+const dir =  process.cwd();
+const fs = require('fs');
+
+function checkThisOut() {
+    filesInDir = fs.readdirSync(dir);
+    constFileOfTheDay = filesInDir[Math.floor(Math.random() * filesInDir.length)];
+    console.log("The file of the day is " + constFileOfTheDay + "! Check it out!");
+}
+
+module.exports = checkThisOut;

--- a/ff.js
+++ b/ff.js
@@ -5,6 +5,7 @@ const [,, ...args] = process.argv;
 const showLog = require('./showLog');
 const commitFiles = require('./commitFiles');
 const branchFiles = require('./branchFiles');
+const checkThisOut = require('./checkThisOut');
 
 if (args.length === 0) {
   showHelp();
@@ -15,7 +16,7 @@ if (args.length === 0) {
 } else if (args[0] === 'merge') {
   console.log('TODO');
 } else if (args[0] === 'checkout') {
-  console.log('TODO');
+  checkThisOut();
 } else if (args[0] === 'log') {
   showLog();
 } else {


### PR DESCRIPTION
We don't actually need a checkout method, cause everything is already right there, in your face. But the people might want `ff checkout` to do something, and we listen to the PEOPLE. Sure, coding standards - we have the best coding standards, believe me - but when you're, when you're caught up and 'lost in the sauce' of UML diagrams and everything, you need to walk down the street, firmly shake a use by the hand, and tell them, 

> Don't worry Billy, you can still run ff checkout.