### PR TITLE
Use alternate naming scheme, fix bug finding greatest suffix

### DIFF
--- a/fileUtils.js
+++ b/fileUtils.js
@@ -1,4 +1,4 @@
-const { settings } = require('./suffixes.js');
+const { parts, gt, settings } = require('./suffixes.js');
 
 const fs = require('fs');
 const dir =  process.cwd();
@@ -26,17 +26,13 @@ function getHighestVersion(filename) {
   //get all files with the name as a prefix
   fs.readdirSync(dir).forEach(file => {
     if (file.startsWith(filename)) {
+      const [[base, ...suffix], ext] = parts(file);
+
       //add it if we don't have one yet 
-      
-      let newSuffix = "";
-      if (file.split(settings.separator).length > 1) {
-        newSuffix = file.split(settings.separator)[1];
-      }
-      
-      if (newSuffix > oldSuffix || highestVerFile === "") {
+      if (highestVerFile === "" || gt(suffix, oldSuffix)) {
         highestVerFile = file;
+        oldSuffix = suffix;
       }
-      
     }
   });
   return highestVerFile;

--- a/suffixes.js
+++ b/suffixes.js
@@ -1,16 +1,16 @@
 const settings = {
   separator: "_",
   suffixes: [
-    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"
-    //"Copy",
-    //"Copy(2)",
-    //"Copy(3)",
-    //"Final",
-    //"Final2",
-    //"REALfinal",
-    //"asdf",
-    //"hjkl",
-    //"pleasebefinal"
+    //"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"
+    "Copy",
+    "Copy(2)",
+    "Copy(3)",
+    "Final",
+    "Final2",
+    "REALfinal",
+    "asdf",
+    "hjkl",
+    "pleasebefinal"
   ]
 };
 
@@ -18,6 +18,25 @@ function parts(filename) {
   // TODO handle dots in the name
   const [name, ext] = filename.split('.');
   return [name.split(settings.separator), `.${ext}`];
+}
+
+function gt(suffixA, suffixB) {
+  const numsA = suffixA.map(str => settings.suffixes.indexOf(str));
+  const numsB = suffixB.map(str => settings.suffixes.indexOf(str));
+  const maxLen = Math.max(suffixA.length, suffixB.length);
+
+  // Left pad with 0s
+  while (numsA.length < maxLen) numsA.unshift(0);
+  while (numsB.length < maxLen) numsB.unshift(0);
+
+  for (let place = 0; place < maxLen; place++) {
+    if (numsA[place] > numsB[place]) {
+      return true;
+    } else if (numsA[place] < numsB[place]) {
+      return false;
+    }
+  }
+  return false;
 }
 
 function inc(filename) {
@@ -79,4 +98,4 @@ function dec(filename) {
   }
 }
 
-module.exports = { settings, parts, dec, inc };
+module.exports = { settings, parts, dec, inc, gt };

--- a/test/suffixes.js
+++ b/test/suffixes.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 
-const { settings, parts, dec, inc } = require('../suffixes');
+const { settings, parts, dec, inc, gt } = require('../suffixes');
 
 settings.suffixes = "0123456789".split('');
 
@@ -25,5 +25,23 @@ describe('dec', function() {
   });
   it('stops at 0', function() {
     assert.equal(dec('test_1.txt'), 'test.txt');
+  });
+});
+
+describe('gt', function() {
+  it('works for single digits', function() {
+    assert.ok(gt(['3'], ['2']));
+    assert.ok(!gt(['2'], ['3']));
+    assert.ok(!gt(['2'], ['2']));
+  });
+  it('works with zeros', function() {
+    assert.ok(gt(['2'], []));
+    assert.ok(!gt([], ['2']));
+  });
+  it('handles different lengths', function() {
+    assert.ok(gt(['2','1'], ['9']));
+    assert.ok(gt(['2'], []));
+    assert.ok(!gt(['9'], ['2','1']));
+    assert.ok(!gt([], ['2']));
   });
 });


### PR DESCRIPTION
This one cycles through some strings instead of numbers (and also meant that I had to convert the strings to the numbers they represent in `getHighestVersion()`

<img width="1229" alt="image" src="https://user-images.githubusercontent.com/5315059/82154322-de59ef00-9821-11ea-94d9-c333ac426afc.png">
